### PR TITLE
fix: remove trailing punctuation from testdata heading

### DIFF
--- a/testdata/markdown_files/sample.md
+++ b/testdata/markdown_files/sample.md
@@ -1,1 +1,1 @@
-## Hello, World!
+## Hello, World


### PR DESCRIPTION
## Summary

`gomarklint v2.15.0` enforces the `no-trailing-punctuation` rule, which caused CI to fail because the heading `## Hello, World!` in `testdata/markdown_files/sample.md` ends with `!`.

## Changes

```diff
-## Hello, World!
+## Hello, World
```