### PR TITLE
docs: update action description to outcome-based copy

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'gomarklint Markdown Linter'
-description: 'Lint Markdown files using gomarklint'
+description: 'Catch broken links before your readers do.'
 author: 'shinagawa-web'
 inputs:
   args:


### PR DESCRIPTION
Change `description` in `action.yml` from feature-based to outcome-based copy.

- Before: `Lint Markdown files using gomarklint`
- After: `Catch broken links before your readers do.`

Consistent with the repository description update on shinagawa-web/gomarklint. This text appears on the GitHub Marketplace listing.